### PR TITLE
require deliberate addition of manx binaries to repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .idea/*
 *.history/*
 .idea
+payloads/manx.go-*


### PR DESCRIPTION
Adds payloads/manx.go-* to .gitignore to prevent accidental updates to static binaries in all future pushes. This makes it so that the addition of manx binaries to the repository are deliberate updates.