### PR TITLE
VIRTS-1697 Don't attempt to connect to 0.0.0.0 via websocket in manx terminal

### DIFF
--- a/static/js/terminal.js
+++ b/static/js/terminal.js
@@ -98,11 +98,19 @@ function checkSpecialKeywords(word) {
 
 function runCommand(input) {
  let sessionId = $('#session-id option:selected').attr('value');
- let websocket = $('#websocket-data').data('websocket');
- let socket = new WebSocket('ws://'+websocket+'/manx/'+sessionId);
+ var [wsHost, wsPort] = $('#websocket-data').data('websocket').split(':');
+
+ if (wsHost === '0.0.0.0'){
+    console.log('WebSocket host configured for 0.0.0.0. Using window location for host/ip instead.');
+    wsHost = window.location.hostname;
+ }
+
+ var socket = new WebSocket('ws://' + wsHost + ':' + wsPort + '/manx/' + sessionId);
+
  socket.onopen = function () {
      socket.send(input);
  };
+
  socket.onmessage = function (s) {
      try {
          let jData = JSON.parse(s.data);


### PR DESCRIPTION
Fixes: https://github.com/mitre/manx/issues/20

### Summary
The `app.contact.websocket` configuration value is used for binding the websocket server socket on the caldera server as well as establishing websocket connections from the remote shell view in a browser.

A value of `0.0.0.0` is fine for establishing a server socket, but any browser running on a remote system will fail to establish a websocket connection to `0.0.0.0`. This manifests as blank remote-shell output when running commands and the following error in a browser dev console (firefox anyway):

```
Firefox can’t establish a connection to the server at ws://0.0.0.0:7012/manx/493151.
```

### What I did
If the configured value is `0.0.0.0`, use the browses window location instead for the host/ip portion of the websocket connection address. The port will still be pulled from the `app.contact.websocket` configuration value.

### Testing
All tests were performed with a manx agent running on a local VM. The remote shell commands used were `whoami` and `ls` for verifying connectivity with the agent. The websocket network view in Chome/Firefox developer tools were used to confirm websocket address values.

* Browser connected to `localhost` and `app.contact.websocket` set to `0.0.0.0:7012` works.
* Browser connected from VM and `app.contact.websocket` set to `0.0.0.0:7012` works.
* Browser connected to `localhost` and `app.contact.websocket` set to VPN-assigned ip address (`10.0.0.0/8`) works (the configured value is used for the websocket connection)
* Browser connected from VM and `app.contact.websocket` set to LAN-assigned ip address works (`192.168.1.0/24`) works (bridged network) (the the configured value is used for the websocket connection).

