### PR TITLE
javascript function to decode base64 into unicode

### DIFF
--- a/static/js/terminal.js
+++ b/static/js/terminal.js
@@ -130,7 +130,7 @@ function runCommand(input) {
 
 function displayCommand(){
     function displayMe(data){
-        $('#delivery-command-terminal').text(atob(data[0].test));
+        $('#delivery-command-terminal').text(b64DecodeUnicode(data[0].test));
     }
     let cmd = $('#dcommands-terminal option:selected');
     stream('Great, you picked '+cmd.text()+'. Now run the command on the host. It will run in the background - but you can change this if you would like.');
@@ -178,8 +178,8 @@ function showProcedure() {
         for (let ab of data) {
             let agent = $('#session-id option:selected');
             if (ab.platform === agent.data("platform") && agent.data("executor") === ab.executor) {
-                term.write(atob(ab.test));
-                input = atob(ab.test);
+                term.write(b64DecodeUnicode(ab.test));
+                input = b64DecodeUnicode(ab.test);
                 return;
             }
         }

--- a/static/js/terminal.js
+++ b/static/js/terminal.js
@@ -178,8 +178,8 @@ function showProcedure() {
         for (let ab of data) {
             let agent = $('#session-id option:selected');
             if (ab.platform === agent.data("platform") && agent.data("executor") === ab.executor) {
-                term.write(b64DecodeUnicode(ab.test));
                 input = b64DecodeUnicode(ab.test);
+                term.write(input);
                 return;
             }
         }


### PR DESCRIPTION
## Description

The front end did not display unicode correctly in many locations. This change uses new Javascript functions to correctly encode and decode unicode to and from base64.

This PR is dependent on https://github.com/mitre/caldera/pull/2130.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested manually to verify that the bug was fixed and that nothing else was broken.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
