### PR TITLE
Websocket protocol per location protocol

### DIFF
--- a/static/js/terminal.js
+++ b/static/js/terminal.js
@@ -105,9 +105,9 @@ function runCommand(input) {
     wsHost = window.location.hostname;
  }
 
- var protocol = (location.protocol == 'https:') ? 'wss://' : 'ws://';
+ var wsProto = (location.protocol == 'https:') ? 'wss://' : 'ws://';
 
- var socket = new WebSocket(protocol + wsHost + ':' + wsPort + '/manx/' + sessionId);
+ var socket = new WebSocket(wsProto + wsHost + ':' + wsPort + '/manx/' + sessionId);
 
  socket.onopen = function () {
      socket.send(input);

--- a/static/js/terminal.js
+++ b/static/js/terminal.js
@@ -105,7 +105,9 @@ function runCommand(input) {
     wsHost = window.location.hostname;
  }
 
- var socket = new WebSocket('ws://' + wsHost + ':' + wsPort + '/manx/' + sessionId);
+ var protocol = (location.protocol == 'https:') ? 'wss://' : 'ws://';
+
+ var socket = new WebSocket(protocol + wsHost + ':' + wsPort + '/manx/' + sessionId);
 
  socket.onopen = function () {
      socket.send(input);


### PR DESCRIPTION
## Description

The WebSocket protocol defines a ws:// and wss:// prefix to indicate a WebSocket and a WebSocket secure connection, respectively. This PR addresses a bug where the ws:// protocol was hardcoded in the connection string causing the WebSocket to fail when using HTTPS.

## Type of change

Minor bug-fix to set the WebSocket protocol per the location protocol property.

- [ x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested in a browser/dev console by loading the Manx terminal in CALDERA over both HTTP and HTTPS and inspecting the protocol value in a debugger to ensure it is set correctly (wss when using https and ws when using http).

## Checklist:

- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
