### PR TITLE
[virts-2456] Creating manx module to comply with golang module changes in 1.17

### DIFF
--- a/app/term_api.py
+++ b/app/term_api.py
@@ -1,3 +1,5 @@
+import os
+import pathlib
 from shutil import which
 
 from aiohttp import web
@@ -52,6 +54,7 @@ class TermApi(BaseService):
             for param in ['contact', 'socket', 'http']:
                 if param in headers:
                     ldflags.append('-X main.%s=%s' % (param, headers[param]))
-            output = 'plugins/%s/payloads/%s-%s' % (plugin, name, platform)
-            await self.file_svc.compile_go(platform, output, file_path, ldflags=' '.join(ldflags))
+            output = str(pathlib.Path('plugins/%s/payloads' % plugin).resolve() / ('%s-%s' % (name, platform)))
+            build_path, build_file = os.path.split(file_path)
+            await self.file_svc.compile_go(platform, output, build_file, ldflags=' '.join(ldflags), build_dir=build_path)
         return await self.app_svc.retrieve_compiled_file(name, platform)

--- a/shells/commands/payloads.go
+++ b/shells/commands/payloads.go
@@ -9,7 +9,7 @@ import (
 	"runtime"
 	"path/filepath"
 
-	"../output"
+	"manx.go/output"
 )
 
 //DropPayloads downloads all required payloads for a command

--- a/shells/commands/payloads.go
+++ b/shells/commands/payloads.go
@@ -9,7 +9,7 @@ import (
 	"runtime"
 	"path/filepath"
 
-	"manx.go/output"
+	"github.com/mitre/manx/shells/output"
 )
 
 //DropPayloads downloads all required payloads for a command

--- a/shells/go.mod
+++ b/shells/go.mod
@@ -1,3 +1,4 @@
-module manx.go
+module github.com/mitre/manx/shells
 
-go 1.16
+go 1.13
+

--- a/shells/go.mod
+++ b/shells/go.mod
@@ -1,0 +1,3 @@
+module manx.go
+
+go 1.16

--- a/shells/manx.go
+++ b/shells/manx.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"./output"
-	"./sockets"
-	"./util"
+	"manx.go/output"
+	"manx.go/sockets"
+	"manx.go/util"
 	"flag"
 	"fmt"
 	"os"

--- a/shells/manx.go
+++ b/shells/manx.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"manx.go/output"
-	"manx.go/sockets"
-	"manx.go/util"
+	"github.com/mitre/manx/shells/output"
+	"github.com/mitre/manx/shells/sockets"
+	"github.com/mitre/manx/shells/util"
 	"flag"
 	"fmt"
 	"os"

--- a/shells/sockets/rawtcp.go
+++ b/shells/sockets/rawtcp.go
@@ -9,9 +9,9 @@ import (
 	"os"
 	"encoding/json"
 
-	"manx.go/commands"
-	"manx.go/util"
-	"manx.go/output"
+	"github.com/mitre/manx/shells/commands"
+	"github.com/mitre/manx/shells/util"
+	"github.com/mitre/manx/shells/output"
 )
 
 //TCP communication

--- a/shells/sockets/rawtcp.go
+++ b/shells/sockets/rawtcp.go
@@ -9,9 +9,9 @@ import (
 	"os"
 	"encoding/json"
 
-	"../commands"
-	"../util"
-	"../output"
+	"manx.go/commands"
+	"manx.go/util"
+	"manx.go/output"
 )
 
 //TCP communication

--- a/shells/sockets/rawudp.go
+++ b/shells/sockets/rawudp.go
@@ -7,7 +7,7 @@ import (
 	"math/rand"
 	"encoding/json"
 	
-	"../output"
+	"manx.go/output"
 )
 
 //UDP communication

--- a/shells/sockets/rawudp.go
+++ b/shells/sockets/rawudp.go
@@ -7,7 +7,7 @@ import (
 	"math/rand"
 	"encoding/json"
 	
-	"manx.go/output"
+	"github.com/mitre/manx/shells/output"
 )
 
 //UDP communication

--- a/update-shells.sh
+++ b/update-shells.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
-GOOS=windows go build -o payloads/manx.go-windows -ldflags="-s -w" shells/manx.go
-GOOS=linux go build -o payloads/manx.go-linux -ldflags="-s -w" shells/manx.go
-GOOS=darwin go build -o payloads/manx.go-darwin -ldflags="-s -w" shells/manx.go
+cwd=$(pwd)
+cd shells
+GOOS=windows go build -o ../payloads/manx.go-windows -ldflags="-s -w" manx.go
+GOOS=linux go build -o ../payloads/manx.go-linux -ldflags="-s -w" manx.go
+GOOS=darwin go build -o ../payloads/manx.go-darwin -ldflags="-s -w" manx.go
+cd $cwd


### PR DESCRIPTION
## Description

creating manx golang module and converting path relative imports to module relative imports.  Path mode imports are going to be phased out in go 1.17
https://blog.golang.org/go116-module-changes

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Built the latest repo on go 1.16 without setting the `GO111MODULE` flag to `no` or `auto`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [NA] I have made corresponding changes to the documentation
- [NA] I have added tests that prove my fix is effective or that my feature works
