### PR TITLE
POC: Returning the http server location instead of the C2 connection string in the agent profile

### DIFF
--- a/shells/manx.go
+++ b/shells/manx.go
@@ -20,14 +20,14 @@ var (
    http = "http://localhost:8888"
 )
 
-func buildProfile(socket string, executors []string) map[string]interface{} {
+func buildProfile(socket string, http string, executors []string) map[string]interface{} {
 	host, _ := os.Hostname()
 	user, _ := user.Current()
 	platform := runtime.GOOS
 	architecture := runtime.GOARCH
 
 	profile := make(map[string]interface{})
-	profile["server"] = socket
+	profile["server"] = http
 	profile["host"] = host
 	profile["username"] = user.Username
 	profile["architecture"] = runtime.GOARCH
@@ -50,7 +50,7 @@ func main() {
 	flag.Var(&executors, "executors", "Comma separated list of executors (first listed is primary)")
 	flag.Parse()
 
-	profile := buildProfile(*socket, executors)
+	profile := buildProfile(*socket, *http, executors)
 
 	output.SetVerbose(*verbose)
 	output.VerbosePrint(fmt.Sprintf("[*] %s outbound socket %s, inbound at %d", *contact, *socket, *inbound))


### PR DESCRIPTION
## Description

A fix for the behavior seen in https://github.com/mitre/caldera/issues/2165
The way things currently run, the C2 connection string is what gets returned in the agent profile to the server, which is used to construct the agent object.  The C2 string is nice to have, but places of replacement of `#{server}` in abilities are expecting the http server, so that seems the more appropriate value to send back.

Ideally we would send back both the http server and the connection strings, so that we could send payloads back and initialize agents with the same C2 channels.  This all is more involved as P2P agents beacon in as upstream agents will have to implement web servers for file uploads and C2 channels for communications (all this work is done already for sandcat and it works in this specific way)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested the same scenario as the issue, and was able to reproduce it, then implement a fix that populates out the ability values correctly.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [NA] I have made corresponding changes to the documentation
- [NA] I have added tests that prove my fix is effective or that my feature works
