### PR TITLE
Adding response time field to comply with new return format

### DIFF
--- a/app/h_terminal.py
+++ b/app/h_terminal.py
@@ -17,5 +17,5 @@ class Handle:
         services.get('contact_svc').report['websocket'].append(
             dict(paw=paw, date=datetime.now().strftime('%Y-%m-%d %H:%M:%S'), cmd=cmd)
         )
-        status, pwd, reply = await handler.send(session_id, cmd)
-        await socket.send(json.dumps(dict(response=reply.strip(), pwd=pwd)))
+        status, pwd, reply, response_time = await handler.send(session_id, cmd)
+        await socket.send(json.dumps(dict(response=reply.strip(), pwd=pwd, status=status, response_time=response_time)))


### PR DESCRIPTION
## Description
Since `handler.send` returns 4 things rather than 3, with the addition of the agent response time, h_terminal.py needs to comply with the new return format.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Ran the manx agent and made sure that command output was returned successfully.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
