### PR TITLE
Switch agent reported time to UTC

### DIFF
--- a/app/h_terminal.py
+++ b/app/h_terminal.py
@@ -1,6 +1,8 @@
 import json
 
-from datetime import datetime
+from datetime import datetime, timezone
+
+from app.utility.base_world import BaseWorld
 
 
 class Handle:
@@ -14,8 +16,8 @@ class Handle:
         cmd = await socket.recv()
         handler = services.get('term_svc').socket_conn.tcp_handler
         paw = next(i.paw for i in handler.sessions if i.id == int(session_id))
-        services.get('contact_svc').report['websocket'].append(
-            dict(paw=paw, date=datetime.now().strftime('%Y-%m-%d %H:%M:%S'), cmd=cmd)
+        services.get('contact_svc').report['WEBSOCKET'].append(
+            dict(paw=paw, date=datetime.now(timezone.utc).strftime(BaseWorld.TIME_FORMAT), cmd=cmd)
         )
         status, pwd, reply, response_time = await handler.send(session_id, cmd)
         await socket.send(json.dumps(dict(response=reply.strip(), pwd=pwd, status=status, response_time=response_time)))

--- a/shells/commands/commands.go
+++ b/shells/commands/commands.go
@@ -24,11 +24,11 @@ func RunCommand(message string, httpServer string, profile map[string]interface{
     } else if (strings.HasPrefix(message, "download")) {
         pieces := strings.Split(message, "download")
         go download(httpServer, pieces[1])
-        return []byte("Download initiated\n"), 0, time.Now()
+        return []byte("Download initiated\n"), 0, getUTCTimeStamp()
     } else if (strings.HasPrefix(message, "upload")) {
         pieces := strings.Split(message, "upload")
         go upload(httpServer, pieces[1])
-        return []byte("Upload initiated\n"), 0, time.Now()
+        return []byte("Upload initiated\n"), 0, getUTCTimeStamp()
     } else {
         bites, status, executionTimestamp := execute(message, strings.Split(reflect.ValueOf(profile["executors"]).String(), ",")[0])
         return bites, status, executionTimestamp
@@ -42,18 +42,18 @@ func execute(command string, executor string) ([]byte, int, time.Time) {
     var executionTimestamp time.Time
     if runtime.GOOS == "windows" {
         if executor == "cmd" {
-            executionTimestamp = time.Now()
+            executionTimestamp = getUTCTimeStamp()
             bites, error = exec.Command("cmd.exe", "/c", command).Output()
         } else {
-            executionTimestamp = time.Now()
+            executionTimestamp = getUTCTimeStamp()
             bites, error = exec.Command("powershell.exe", "-ExecutionPolicy", "Bypass", "-C", command).Output()
         }
     } else {
-        executionTimestamp = time.Now()
+        executionTimestamp = getUTCTimeStamp()
         bites, error = exec.Command("sh", "-c", command).Output()
     }
     if error != nil {
-        executionTimestamp = time.Now()
+        executionTimestamp = getUTCTimeStamp()
         bites = []byte(string(error.Error()))
         status = 1
 	}
@@ -61,7 +61,7 @@ func execute(command string, executor string) ([]byte, int, time.Time) {
 }
 
 func changeDirectory(target string) ([]byte, time.Time) {
-    executionTimestamp := time.Now()
+    executionTimestamp := getUTCTimeStamp()
     os.Chdir(strings.TrimSpace(target))
     return []byte(" "), executionTimestamp
 }
@@ -119,4 +119,8 @@ func upload(server string, file string) []byte {
     }
     resp.Body.Close()
     return []byte(" ")
+}
+
+func getUTCTimeStamp() time.Time {
+	return time.Now().UTC()
 }

--- a/shells/sockets/rawtcp.go
+++ b/shells/sockets/rawtcp.go
@@ -46,7 +46,7 @@ func listen(conn net.Conn, profile map[string]interface{}, server string) {
 		response["response"] = string(bites)
 		response["status"] = status
 		response["pwd"] = pwd
-		response["agent_reported_time"] = util.GetFormattedTimestamp(commandTimestamp, "2006-01-02 03:04:05")
+		response["agent_reported_time"] = util.GetFormattedTimestamp(commandTimestamp, "2006-01-02T15:04:05Z")
 		jdata, _ := json.Marshal(response)
 		conn.Write(jdata)
     }


### PR DESCRIPTION
## Description

Links expect the `agent_reported_time` to be in UTC format, so this PR ensures that manx agents set that time correctly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Operations ran on manx agents can now save links.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
