### PR TITLE
lowercase websocket

### DIFF
--- a/app/h_terminal.py
+++ b/app/h_terminal.py
@@ -16,7 +16,7 @@ class Handle:
         cmd = await socket.recv()
         handler = services.get('term_svc').socket_conn.tcp_handler
         paw = next(i.paw for i in handler.sessions if i.id == int(session_id))
-        services.get('contact_svc').report['WEBSOCKET'].append(
+        services.get('contact_svc').report['websocket'].append(
             dict(paw=paw, date=datetime.now(timezone.utc).strftime(BaseWorld.TIME_FORMAT), cmd=cmd)
         )
         status, pwd, reply, response_time = await handler.send(session_id, cmd)


### PR DESCRIPTION
## Description

Changed case of `WEBSOCKET` to `websocket`. This bring it in line with websocket contact class capitalization and fixes the training plugin manx flag.

https://github.com/mitre/caldera/blob/128a9b08e9d2d1a5c6939d9a200e5681db9593ad/app/contacts/contact_websocket.py#L10

https://github.com/mitre/training/blob/master/app/flags/plugins/manx/flag_0.py

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested with the training plugin's manx flag. Ensured that the flag was triggered and that one can proceed to next challenge. Completing this flag implied that the change did not alter the behavior of the manx plugin.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
