### PR TITLE
sanitize user-provided compilation parameters

### DIFF
--- a/app/term_api.py
+++ b/app/term_api.py
@@ -61,11 +61,8 @@ class TermApi(BaseService):
             for param in ['contact', 'socket', 'http']:
                 if param in headers:
                     value = headers[param]
-                    if param == 'contact':
-                        value = self.file_svc.sanitize_ldflag_value(value)
-                    else:
-                        value = self.file_svc.sanitize_server_ldflag_value(value)
-                    ldflags.append('-X main.%s=%s' % (param, value))
+                    sanitized = self.file_svc.sanitize_ldflag_value(param, value)
+                    ldflags.append('-X main.%s=%s' % (param, sanitized))
             output = str(pathlib.Path('plugins/%s/payloads' % plugin).resolve() / ('%s-%s' % (name, platform)))
             build_path, build_file = os.path.split(file_path)
             await self.file_svc.compile_go(platform, output, build_file, ldflags=' '.join(ldflags), build_dir=build_path)

--- a/app/term_api.py
+++ b/app/term_api.py
@@ -60,7 +60,12 @@ class TermApi(BaseService):
             ldflags = ['-s', '-w', '-X main.key=%s' % (self.generate_name(size=30),)]
             for param in ['contact', 'socket', 'http']:
                 if param in headers:
-                    ldflags.append('-X main.%s=%s' % (param, headers[param]))
+                    value = headers[param]
+                    if param == 'contact':
+                        value = self.file_svc.sanitize_ldflag_value(value)
+                    else:
+                        value = self.file_svc.sanitize_server_ldflag_value(value)
+                    ldflags.append('-X main.%s=%s' % (param, value))
             output = str(pathlib.Path('plugins/%s/payloads' % plugin).resolve() / ('%s-%s' % (name, platform)))
             build_path, build_file = os.path.split(file_path)
             await self.file_svc.compile_go(platform, output, build_file, ldflags=' '.join(ldflags), build_dir=build_path)

--- a/app/term_api.py
+++ b/app/term_api.py
@@ -60,8 +60,7 @@ class TermApi(BaseService):
             ldflags = ['-s', '-w', '-X main.key=%s' % (self.generate_name(size=30),)]
             for param in ['contact', 'socket', 'http']:
                 if param in headers:
-                    value = headers[param]
-                    sanitized = self.file_svc.sanitize_ldflag_value(param, value)
+                    sanitized = self.file_svc.sanitize_ldflag_value(param, headers[param])
                     ldflags.append('-X main.%s=%s' % (param, sanitized))
             output = str(pathlib.Path('plugins/%s/payloads' % plugin).resolve() / ('%s-%s' % (name, platform)))
             build_path, build_file = os.path.split(file_path)

--- a/shells/manx.go
+++ b/shells/manx.go
@@ -42,9 +42,9 @@ func buildProfile(socket string, executors []string) map[string]interface{} {
 
 func main() {
 	var executors util.ListFlags
-	contact := flag.String("contact", "tcp", "Which contact to use")
-	socket := flag.String("socket", "0.0.0.0:7010", "The ip:port of the socket listening post")
-	http := flag.String("http", "http://127.0.0.1:8888", "The FQDN of the HTTP listening post")
+	contact := flag.String("contact", contact, "Which contact to use")
+	socket := flag.String("socket", socket, "The ip:port of the socket listening post")
+	http := flag.String("http", http, "The FQDN of the HTTP listening post")
 	inbound := flag.Int("inbound", 6000, "A port to use for inbound connections")
 	verbose := flag.Bool("v", false, "Enable verbose output")
 	flag.Var(&executors, "executors", "Comma separated list of executors (first listed is primary)")


### PR DESCRIPTION
## Description
- Sanitize user-provided header values for custom manx compilation to avoid RCE
- Fix manx source code to use custom header values

Required PR: https://github.com/mitre/caldera/pull/3129

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Tested building manx with valid and invalid header values

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
